### PR TITLE
fix qobuz instance opened twice

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -23,12 +23,18 @@ const createWindow = () => {
 }
 
 
+const gotTheLock = app.requestSingleInstanceLock({});
+if (!gotTheLock) {
+  app.quit();
+}
 
 app.on('window-all-closed', () => {
     if (process.platform !== 'darwin') app.quit()
 })
 
-
+app.on("second-instance", () => {
+  win.show();
+});
 
 app.whenReady().then(() => {
 


### PR DESCRIPTION
Hello,

Thank you for making this app available!

This is a small PR to fix an issue where opening the app window was creating a new instance, instead of reusing the current instance if it exists. This was bugging me since I have the habit of focusing apps with "menu key"+"app name" even after I have opened them. With this PR, you can reopen the current instance after it is reduced to tray with keyboard shortcuts, instead of using the context menu.

This was the behavior before (notice the second Qobuz icon in the tray after second launch):

[qobuz tray before.webm](https://github.com/user-attachments/assets/1c66c8e6-f6b2-476a-a131-06c351bbabec)

This is after (notice that the first instance is focused after the second start):

[qobuz tray after.webm](https://github.com/user-attachments/assets/752cbd3e-e9eb-4d1d-8280-a618251710a2)