### PR TITLE
Fixing spacing / border issues with updated electron-wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dist
 .pnp.*
 
 venv/
+
+# Crush directory
+.crush

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,14 @@ const createWindow = () => {
     win = new BrowserWindow({
       width: 1200,
       height: 800,
-      icon: path.join(__dirname, "../resources/icons/clearicon.png")
+      icon: path.join(__dirname, "../resources/icons/clearicon.png"),
+      webPreferences: {
+        webSecurity: false,
+        contextIsolation: false
+      },
+      useContentSize: true,
+      frame: true,
+      titleBarStyle: 'default'
     })
     win.removeMenu()
     win.loadURL(qobuz_url)

--- a/src/main.js
+++ b/src/main.js
@@ -11,10 +11,6 @@ const createWindow = () => {
       width: 1200,
       height: 800,
       icon: path.join(__dirname, "../resources/icons/clearicon.png"),
-      webPreferences: {
-        webSecurity: false,
-        contextIsolation: false
-      },
       useContentSize: true,
       frame: true,
       titleBarStyle: 'default'


### PR DESCRIPTION
The updated electron-wrapper has a new border width param / default that we need to remove or else we have empty space around the window!

This was assisted by claude!